### PR TITLE
add image building to pr gha workflow

### DIFF
--- a/.github/workflows/pr_build.yaml
+++ b/.github/workflows/pr_build.yaml
@@ -162,3 +162,25 @@ jobs:
         with:
           name: spiffe-helper
           path: spiffe-helper
+
+  build-images:
+    runs-on: ubuntu-22.04
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Install regctl
+        uses: regclient/actions/regctl-installer@main
+      - name: Build image
+        run: make docker-build


### PR DESCRIPTION
This PR builds includes building the docker image(s) as part of the the PR GitHub Action workflow. 



